### PR TITLE
Add size guide modal assets

### DIFF
--- a/assets/size-guide-modal.css
+++ b/assets/size-guide-modal.css
@@ -1,0 +1,150 @@
+.size-guide-modal {
+  box-sizing: border-box;
+  opacity: 0;
+  position: fixed;
+  visibility: hidden;
+  z-index: -1;
+  margin: 0 auto;
+  top: 0;
+  left: 0;
+  overflow: auto;
+  width: 100%;
+  background: rgba(var(--color-foreground), 0.2);
+  height: 100%;
+}
+
+.size-guide-modal[open] {
+  opacity: 1;
+  visibility: visible;
+  z-index: 101;
+}
+
+.size-guide-modal__content {
+  border-radius: var(--popup-corner-radius);
+  background-color: rgb(var(--color-background));
+  overflow: auto;
+  height: 80%;
+  margin: 0 auto;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 5rem;
+  width: 92%;
+  position: absolute;
+  top: 0;
+  padding: 0 1.5rem 0 3rem;
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
+  border-style: solid;
+  border-width: var(--popup-border-width);
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius)
+    rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
+.size-guide-modal__content.focused {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3),
+    var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius)
+      rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
+.size-guide-modal__content:focus-visible {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3),
+    var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius)
+      rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
+@media screen and (min-width: 750px) {
+  .size-guide-modal__content {
+    padding-right: 1.5rem;
+    margin-top: 10rem;
+    width: 70%;
+    padding: 0 3rem;
+  }
+
+  .product-media-modal__dialog .global-media-settings--no-shadow {
+    overflow: visible !important;
+  }
+}
+
+.size-guide-modal__content img {
+  max-width: 100%;
+}
+
+@media screen and (max-width: 749px) {
+  .size-guide-modal__content table {
+    display: block;
+    max-width: fit-content;
+    overflow-x: auto;
+    white-space: nowrap;
+    margin: 0;
+  }
+
+  .product-media-modal__dialog .global-media-settings,
+  .product-media-modal__dialog .global-media-settings video,
+  .product-media-modal__dialog .global-media-settings model-viewer,
+  .product-media-modal__dialog .global-media-settings iframe,
+  .product-media-modal__dialog .global-media-settings img {
+    border: none;
+    border-radius: 0;
+  }
+}
+
+.size-guide-modal__opener {
+  display: inline-block;
+}
+
+.size-guide-modal__button {
+  font-size: 1.6rem;
+  padding-right: 1.3rem;
+  padding-left: 0;
+  min-height: 4.4rem;
+  text-underline-offset: 0.3rem;
+  text-decoration-thickness: 0.1rem;
+  transition: text-decoration-thickness var(--duration-short) ease;
+}
+
+.size-guide-modal__button:hover {
+  text-decoration-thickness: 0.2rem;
+}
+
+.size-guide-modal__content-info {
+  padding-right: 4.4rem;
+}
+
+.size-guide-modal__content-info > * {
+  height: auto;
+  margin: 0 auto;
+  max-width: 100%;
+  width: 100%;
+}
+
+@media screen and (max-width: 749px) {
+  .size-guide-modal__content-info > * {
+    max-height: 100%;
+  }
+}
+
+.size-guide-modal__toggle {
+  background-color: rgb(var(--color-background));
+  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border-radius: 50%;
+  color: rgba(var(--color-foreground), 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  position: sticky;
+  padding: 1.2rem;
+  z-index: 2;
+  top: 1.5rem;
+  width: 4rem;
+  margin: 0 0 0 auto;
+}
+
+.size-guide-modal__toggle:hover {
+  color: rgba(var(--color-foreground), 0.75);
+}
+
+.size-guide-modal__toggle .icon {
+  height: auto;
+  margin: 0;
+  width: 2.2rem;
+}

--- a/snippets/size-guide-modal.liquid
+++ b/snippets/size-guide-modal.liquid
@@ -1,0 +1,13 @@
+{{ 'size-guide-modal.css' | asset_url | stylesheet_tag }}
+
+<modal-dialog id="SizeGuideModal" class="size-guide-modal">
+  <div role="dialog" aria-modal="true" class="size-guide-modal__content" tabindex="-1">
+    <button type="button" class="size-guide-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">
+      {{ 'icon-close.svg' | inline_asset_content }}
+    </button>
+    <div class="size-guide-modal__content-info">
+      {%- comment -%} Size guide content goes here {%- endcomment -%}
+      {{ size_guide_content }}
+    </div>
+  </div>
+</modal-dialog>


### PR DESCRIPTION
## Summary
- create `size-guide-modal.css` with overlay styles
- add new snippet `size-guide-modal.liquid` referencing the stylesheet

## Testing
- `theme-check` *(fails: command not found)*