### PR TITLE
Add size guide modal block

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -455,6 +455,8 @@
                     {{ block.settings.text | default: block.settings.page.title | escape }}
                   </button>
                 </modal-opener>
+              {%- when 'size_guide' -%}
+                {% render 'size-guide-modal', block: block, content: product.metafields.custom.size_guide %}
               {%- when 'share' -%}
                 {% liquid
                   assign share_url = product.selected_variant.url | default: product.url | prepend: request.origin
@@ -1164,6 +1166,19 @@
           "id": "page",
           "type": "page",
           "label": "t:sections.main-product.blocks.popup.settings.page.label"
+        }
+      ]
+    },
+    {
+      "type": "size_guide",
+      "name": "Size guide",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "text",
+          "id": "label",
+          "default": "Size guide",
+          "label": "Button label"
         }
       ]
     },

--- a/snippets/size-guide-modal.liquid
+++ b/snippets/size-guide-modal.liquid
@@ -1,0 +1,28 @@
+{% comment %}
+  Renders a modal with size guide content.
+
+  Accepts:
+  - block: {Object} Block object for settings
+  - content: {String} HTML content to display
+
+  Usage:
+  {% render 'size-guide-modal', block: block, content: product.metafields.custom.size_guide %}
+{% endcomment %}
+
+{% if content != blank %}
+  <modal-opener data-modal="#SizeGuideModal-{{ section.id }}-{{ block.id }}" class="size-guide-modal__opener">
+    <button type="button" class="size-guide-modal__button link" aria-haspopup="dialog">
+      {{ block.settings.label }}
+    </button>
+  </modal-opener>
+  <modal-dialog id="SizeGuideModal-{{ section.id }}-{{ block.id }}" class="size-guide-modal" {{ block.shopify_attributes }}>
+    <div role="dialog" aria-label="{{ block.settings.label }}" aria-modal="true" class="size-guide-modal__content" tabindex="-1">
+      <button type="button" class="size-guide-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">
+        {{ 'icon-close.svg' | inline_asset_content }}
+      </button>
+      <div class="size-guide-modal__content-info rte">
+        {{ content }}
+      </div>
+    </div>
+  </modal-dialog>
+{% endif %}


### PR DESCRIPTION
## Summary
- add a snippet that renders a size guide modal
- add new block type `size_guide` to Main Product section
- render the size guide modal block in product info

## Testing
- `theme-check` *(fails: command not found)*