### PR TITLE
Add FAQ and Lookbook translations

### DIFF
--- a/locales/bg.json
+++ b/locales/bg.json
@@ -373,6 +373,16 @@
       "step_error": "Можете да добавяте този артикул само на групи от {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Държава/регион",
     "language_label": "Език",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -397,6 +397,16 @@
       "step_error": "Tuto položku můžete přidat jen v přírůstcích hodnoty: {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Země/oblast",
     "language_label": "Jazyk",

--- a/locales/da.json
+++ b/locales/da.json
@@ -373,6 +373,16 @@
       "step_error": "Du kan kun tilføje denne vare i intervaller på {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Land/område",
     "language_label": "Sprog",

--- a/locales/de.json
+++ b/locales/de.json
@@ -373,6 +373,16 @@
       "step_error": "Du kannst diesen Artikel nur in Abstufungen von {{ step }} hinzufügen."
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Land/Region",
     "language_label": "Sprache",

--- a/locales/el.json
+++ b/locales/el.json
@@ -373,6 +373,16 @@
       "step_error": "Μπορείτε να προσθέσετε αυτό το προϊόν μόνο κατά βήματα των {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Χώρα/περιοχή",
     "language_label": "Γλώσσα",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -372,6 +372,16 @@
       "min_error": "This item has a minimum of {{ min }}",
       "max_error": "This item has a maximum of {{ max }}",
       "step_error": "You can only add this item in increments of {{ step }}"
+    },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
     }
   },
   "localization": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -385,6 +385,16 @@
       "step_error": "Solo puedes agregar este artículo en incrementos de {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "País/región",
     "language_label": "Idioma",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -373,6 +373,16 @@
       "step_error": "Voit lisätä tätä tuotetta vain {{ step }}:n lisäyksinä"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Maa/alue",
     "language_label": "Kieli",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -385,6 +385,16 @@
       "step_error": "Vous pouvez ajouter cet article uniquement par incréments de {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Pays/région",
     "language_label": "Langue",

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -385,6 +385,16 @@
       "step_error": "Ovaj artikl možete dodavati samo u rasponima povećanja od {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Država/regija",
     "language_label": "Jezik",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -373,6 +373,16 @@
       "step_error": "A termék mennyisége csak {{ step }} darabos lépésekben növelhető"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Ország/régió",
     "language_label": "Nyelv",

--- a/locales/id.json
+++ b/locales/id.json
@@ -373,6 +373,16 @@
       "step_error": "Anda hanya dapat menambahkan item ini secara inkremental sebesar {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Negara/Wilayah",
     "language_label": "Bahasa",

--- a/locales/it.json
+++ b/locales/it.json
@@ -385,6 +385,16 @@
       "step_error": "Puoi aggiungere questo articolo solo in incrementi di {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Paese/Area geografica",
     "language_label": "Lingua",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -373,6 +373,16 @@
       "step_error": "このアイテムは、{{ step }}の増分でのみ追加できます"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "国/地域",
     "language_label": "言語",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -373,6 +373,16 @@
       "step_error": "이 품목은 {{ step }}개 단위로만 추가할 수 있습니다."
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "국가/지역",
     "language_label": "언어",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -397,6 +397,16 @@
       "step_error": "Galima pridėti tik po {{ step }} vnt. šios prekės"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Šalis / regionas",
     "language_label": "Kalba",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -373,6 +373,16 @@
       "step_error": "Du kan bare legge til denne varen i multipler av {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Land/region",
     "language_label": "Språk",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -373,6 +373,16 @@
       "step_error": "Je kunt dit artikel alleen toevoegen in stappen van {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Land/regio",
     "language_label": "Taal",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -397,6 +397,16 @@
       "step_error": "Możesz dodać tę pozycję tylko z przyrostem o {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Kraj/region",
     "language_label": "Język",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -385,6 +385,16 @@
       "step_error": "Só é possível adicionar este item em incrementos de {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "País/Região",
     "language_label": "Idioma",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -385,6 +385,16 @@
       "step_error": "Só pode adicionar este item em incrementos de {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "País/região",
     "language_label": "Idioma",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -385,6 +385,16 @@
       "step_error": "Poți introduce acest articol numai în incrementuri de {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Țară/Regiune",
     "language_label": "Limbă",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -397,6 +397,16 @@
       "step_error": "Вы можете добавить этот товар только в количестве, кратном {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Страна/регион",
     "language_label": "Язык",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -397,6 +397,16 @@
       "step_error": "Túto položku môžete pridať iba v prírastkoch po {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Krajina/oblasť",
     "language_label": "Jazyk",

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -397,6 +397,16 @@
       "step_error": "Ta artikel lahko dodate samo v korakih po {{ step }}."
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Država/regija",
     "language_label": "Jezik",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -373,6 +373,16 @@
       "step_error": "Du kan endast lägga till den här artikeln med ökningar om {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Land/Region",
     "language_label": "Språk",

--- a/locales/th.json
+++ b/locales/th.json
@@ -373,6 +373,16 @@
       "step_error": "คุณสามารถเพิ่มสินค้านี้ได้ทีละ {{ step }} รายการในแต่ละครั้งเท่านั้น"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "ประเทศ/ภูมิภาค",
     "language_label": "ภาษา",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -373,6 +373,16 @@
       "step_error": "Bu öğeyi yalnızca {{ step }} değerinde artışlarla ekleyebilirsiniz"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Ülke/bölge",
     "language_label": "Dil",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -373,6 +373,16 @@
       "step_error": "Bạn chỉ có thể thêm mặt hàng này theo đơn vị giao dịch {{ step }}"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "Quốc gia/khu vực",
     "language_label": "Ngôn ngữ",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -373,6 +373,16 @@
       "step_error": "您只能以 {{ step }} 为增量来添加此商品"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "国家/地区",
     "language_label": "语言",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -373,6 +373,16 @@
       "step_error": "只能以 {{ step }} 為增量新增此品項"
     }
   },
+    "faq": {
+      "title": "FAQ",
+      "question": "Question",
+      "answer": "Answer"
+    },
+    "lookbook": {
+      "title": "Lookbook",
+      "image": "Image",
+      "link": "Link"
+    },
   "localization": {
     "country_label": "國家/地區",
     "language_label": "語言",


### PR DESCRIPTION
## Summary
- add `faq` and `lookbook` section labels in all locales

## Testing
- `grep -n "faq" locales/fr.json`
