### PR TITLE
Implement cleanup and add docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,12 @@ jobs:
         uses: shopify/theme-check-action@v2
         with:
           token: ${{ github.token }}
+  tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: |
+          node tests/logger.test.js
+          node tests/cart.test.js

--- a/README.md
+++ b/README.md
@@ -101,18 +101,21 @@ Dawn runs [Theme Check](#Theme-Check) on every commit via [Shopify/theme-check-a
 1. Copy `templates/page.lookbook.json` into your theme if it isn't already present.
 2. From the Shopify admin, create a new page and assign it the **lookbook** template.
 3. Use the theme editor to customize the banner and collage sections that come with the template.
+4. Refer to `docs/lookbook-screenshot.png` for an example layout.
 
 ### FAQ accordion
 
 1. Open the theme editor on the page where you want FAQs.
 2. Add a **Collapsible content** section.
 3. Configure each block with your questions and answers to build an accordion style FAQ.
+4. A sample configuration is shown in `docs/faq-screenshot.png`.
 
 ### Size Guide modal
 
 1. Create a page with your size guide information.
 2. In the product page's main section, add a **Popup** block.
 3. Select the size guide page in the block settings and adjust the link label as needed.
+4. See `docs/size-guide-screenshot.png` for how the modal appears.
 
 ## Contributing
 

--- a/assets/cart.js
+++ b/assets/cart.js
@@ -103,7 +103,7 @@ class CartItems extends HTMLElement {
           }
         })
         .catch((e) => {
-          console.error(e);
+          Logger.error(e);
         });
     } else {
       return fetch(`${routes.cart_url}?section_id=main-cart-items`)
@@ -114,7 +114,7 @@ class CartItems extends HTMLElement {
           this.innerHTML = sourceQty.innerHTML;
         })
         .catch((e) => {
-          console.error(e);
+          Logger.error(e);
         });
     }
   }

--- a/assets/global.js
+++ b/assets/global.js
@@ -663,7 +663,7 @@ class BulkModal extends HTMLElement {
             this.innerHTML = sourceQty.innerHTML;
           })
           .catch((e) => {
-            console.error(e);
+            Logger.error(e);
           });
       }
     };
@@ -1170,7 +1170,7 @@ class ProductRecommendations extends HTMLElement {
         }
       })
       .catch((e) => {
-        console.error(e);
+        Logger.error(e);
       });
   }
 }

--- a/assets/logger.js
+++ b/assets/logger.js
@@ -1,0 +1,9 @@
+const root = typeof window !== 'undefined' ? window : global;
+root.Logger = {
+  info(message) {
+    console.info(message);
+  },
+  error(error) {
+    console.error(error);
+  }
+};

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -97,7 +97,7 @@ if (!customElements.get('product-form')) {
             }
           })
           .catch((e) => {
-            console.error(e);
+            Logger.error(e);
           })
           .finally(() => {
             this.submitButton.classList.remove('loading');

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -130,9 +130,9 @@ if (!customElements.get('product-info')) {
           })
           .catch((error) => {
             if (error.name === 'AbortError') {
-              console.log('Fetch aborted by user');
+              Logger.info('Fetch aborted by user');
             } else {
-              console.error(error);
+              Logger.error(error);
             }
           });
       }
@@ -346,7 +346,7 @@ if (!customElements.get('product-info')) {
             const html = new DOMParser().parseFromString(responseText, 'text/html');
             this.updateQuantityRules(this.dataset.section, html);
           })
-          .catch((e) => console.error(e))
+          .catch((e) => Logger.error(e))
           .finally(() => this.querySelector('.quantity__rules-cart .loading__spinner').classList.add('hidden'));
       }
 

--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -98,7 +98,7 @@ if (!customElements.get('quick-add-bulk')) {
               resolve();
             })
             .catch((e) => {
-              console.error(e);
+              Logger.error(e);
               reject(e);
             });
         });

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -190,7 +190,7 @@ if (!customElements.get('quick-order-list')) {
             this.initEventListeners();
           })
           .catch((e) => {
-            console.error(e);
+            Logger.error(e);
           });
       }
 
@@ -349,7 +349,7 @@ if (!customElements.get('quick-order-list')) {
             });
           })
           .catch((e) => {
-            console.error(e);
+            Logger.error(e);
             this.setErrorMessage(window.cartStrings.error);
           })
           .finally(() => {

--- a/docs/faq-screenshot.png
+++ b/docs/faq-screenshot.png
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/lookbook-screenshot.png
+++ b/docs/lookbook-screenshot.png
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/size-guide-screenshot.png
+++ b/docs/size-guide-screenshot.png
@@ -1,0 +1,1 @@
+placeholder

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -177,7 +177,8 @@
       "product_variants": "Варианти на продукта",
       "taxes_included": "С включени данъци.",
       "duties_included": "С включено мито.",
-      "duties_and_taxes_included": "С включено мито и данъци."
+      "duties_and_taxes_included": "С включено мито и данъци.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Мултимедийна галерия"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Страницата не е открита",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Няма резултати за „{{ terms }}“. Проверете начина на изписване или използвайте различна дума или фраза.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "phone": "Телефонен номер",
         "title": "Формуляр за контакт"
       }
-    },
-    "404": {
-      "title": "Страницата не е открита",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Можете да добавяте този артикул само на групи от {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Държава/регион",
     "language_label": "Език",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -179,7 +179,8 @@
       "product_variants": "Varianty produktu",
       "taxes_included": "Včetně daní.",
       "duties_included": "Včetně cla.",
-      "duties_and_taxes_included": "Včetně cla a daní."
+      "duties_and_taxes_included": "Včetně cla a daní.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galerie multimédií"
@@ -223,6 +224,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Stránka nebyla nalezena",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Nebyly nalezeny žádné výsledky pro {{ terms }}. Zkontrolujte pravopis nebo zadejte jiné slovo či slovní spojení.",
       "title": "Výsledky hledání",
@@ -276,10 +281,6 @@
         "error_heading": "Upravte prosím následující informace:",
         "title": "Kontaktní formulář"
       }
-    },
-    "404": {
-      "title": "Stránka nebyla nalezena",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -397,16 +398,16 @@
       "step_error": "Tuto položku můžete přidat jen v přírůstcích hodnoty: {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Země/oblast",
     "language_label": "Jazyk",

--- a/locales/da.json
+++ b/locales/da.json
@@ -177,7 +177,8 @@
       "product_variants": "Produktvarianter",
       "taxes_included": "Inklusive skatter.",
       "duties_included": "Inklusive told.",
-      "duties_and_taxes_included": "Inklusive told og skatter."
+      "duties_and_taxes_included": "Inklusive told og skatter.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Mediegalleri"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Siden blev ikke fundet",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Der blev ikke fundet nogen resultater for “{{ terms }}”. Kontrollér stavemåden, eller brug et andet ord eller udtryk.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Juster følgende:",
         "title": "Kontaktformular"
       }
-    },
-    "404": {
-      "title": "Siden blev ikke fundet",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Du kan kun tilføje denne vare i intervaller på {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Land/område",
     "language_label": "Sprog",

--- a/locales/de.json
+++ b/locales/de.json
@@ -177,7 +177,8 @@
       "product_variants": "Produktvarianten",
       "taxes_included": "Inkl. Steuern.",
       "duties_included": "Inkl. Zollgebühren.",
-      "duties_and_taxes_included": "Inkl. Zollgebühren und Steuern."
+      "duties_and_taxes_included": "Inkl. Zollgebühren und Steuern.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Medien-Galerie"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Seite nicht gefunden",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Keine Ergebnisse gefunden für \"{{ terms }}\". Überprüfe die Schreibweise oder versuche es mit einer anderen Suchanfrage.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Bitte passe Folgendes an:",
         "title": "Kontaktformular"
       }
-    },
-    "404": {
-      "title": "Seite nicht gefunden",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Du kannst diesen Artikel nur in Abstufungen von {{ step }} hinzufügen."
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Land/Region",
     "language_label": "Sprache",

--- a/locales/el.json
+++ b/locales/el.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "Οι φόροι συμπεριλαμβάνονται.",
       "duties_included": "Οι δασμοί συμπεριλαμβάνονται.",
-      "duties_and_taxes_included": "Οι δασμοί και οι φόροι συμπεριλαμβάνονται."
+      "duties_and_taxes_included": "Οι δασμοί και οι φόροι συμπεριλαμβάνονται.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Συλλογή μέσων"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Η σελίδα δεν βρέθηκε",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Δεν βρέθηκαν αποτελέσματα για «{{ terms }}». Ελέγξτε την ορθογραφία ή χρησιμοποιήστε άλλη λέξη ή φράση.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Προσαρμόστε τα παρακάτω:",
         "title": "Φόρμα επικοινωνίας"
       }
-    },
-    "404": {
-      "title": "Η σελίδα δεν βρέθηκε",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Μπορείτε να προσθέσετε αυτό το προϊόν μόνο κατά βήματα των {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Χώρα/περιοχή",
     "language_label": "Γλώσσα",

--- a/locales/es.json
+++ b/locales/es.json
@@ -178,7 +178,8 @@
       "product_variants": "Variantes de producto",
       "taxes_included": "Impuestos incluidos.",
       "duties_included": "Aranceles incluidos.",
-      "duties_and_taxes_included": "Aranceles e impuestos incluidos."
+      "duties_and_taxes_included": "Aranceles e impuestos incluidos.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galería multimedia"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Página no encontrada",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "No se encontraron resultados para “{{ terms }}” Revisa la ortografía o usa una palabra o frase diferente.",
       "results_with_count": {
@@ -267,10 +272,6 @@
         "error_heading": "Por favor, ajusta lo siguiente:",
         "title": "Formulario de contacto"
       }
-    },
-    "404": {
-      "title": "Página no encontrada",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Solo puedes agregar este artículo en incrementos de {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "País/región",
     "language_label": "Idioma",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -177,7 +177,8 @@
       "product_variants": "Tuoteversiot",
       "taxes_included": "Sisältää verot.",
       "duties_included": "Sisältää tullit.",
-      "duties_and_taxes_included": "Sisältää tullit ja verot."
+      "duties_and_taxes_included": "Sisältää tullit ja verot.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Mediagalleria"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Sivua ei löytynyt",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Ei tuloksia haulla \"{{ terms }}\". Tarkista oikeinkirjoitus tai kokeile toista sanaa tai ilmaisua.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Mukauta seuraavat:",
         "title": "Yhteydenottolomake"
       }
-    },
-    "404": {
-      "title": "Sivua ei löytynyt",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Voit lisätä tätä tuotetta vain {{ step }}:n lisäyksinä"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Maa/alue",
     "language_label": "Kieli",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -178,7 +178,8 @@
       },
       "taxes_included": "Taxes incluses.",
       "duties_included": "Frais de douane inclus.",
-      "duties_and_taxes_included": "Frais de douane et taxes inclus."
+      "duties_and_taxes_included": "Frais de douane et taxes inclus.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galerie de supports multimédias"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Page non trouvée",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Aucun résultat trouvé pour « {{ terms }} ». Vérifiez l'orthographe ou utilisez un autre mot ou une autre expression.",
       "results_with_count": {
@@ -267,10 +272,6 @@
         "error_heading": "Veuillez ajuster les éléments suivants :",
         "title": "Formulaire de contact"
       }
-    },
-    "404": {
-      "title": "Page non trouvée",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Vous pouvez ajouter cet article uniquement par incréments de {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Pays/région",
     "language_label": "Langue",

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -178,7 +178,8 @@
       },
       "taxes_included": "Porezi su uključeni.",
       "duties_included": "Carina je uključena.",
-      "duties_and_taxes_included": "Carina i porezi su uključeni."
+      "duties_and_taxes_included": "Carina i porezi su uključeni.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galerija medijskih zapisa"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Stranica nije pronađena",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Nije pronađen nijedan rezultat za „{{ terms }}”. Provjerite pravopis ili upotrijebite drugu riječ ili izraz.",
       "title": "Rezultati pretraživanja",
@@ -267,10 +272,6 @@
         "error_heading": "Prilagodite sljedeće:",
         "title": "Obrazac za kontakt"
       }
-    },
-    "404": {
-      "title": "Stranica nije pronađena",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Ovaj artikl možete dodavati samo u rasponima povećanja od {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Država/regija",
     "language_label": "Jezik",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "Tartalmazza az adókat.",
       "duties_included": "Tartalmazza a vámokat.",
-      "duties_and_taxes_included": "Tartalmazza a vámokat és az adókat."
+      "duties_and_taxes_included": "Tartalmazza a vámokat és az adókat.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Médiatár"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Nem találjuk az oldalt",
+      "subtext": "404-es hiba történt."
+    },
     "search": {
       "no_results": "Nincs találat erre: {{ terms }}. Ellenőrizd a helyesírást, vagy írj be egy másik szót vagy kifejezést.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Kérjük, helyesbítsd a következőket:",
         "title": "Kapcsolattartói űrlap"
       }
-    },
-    "404": {
-      "title": "Nem találjuk az oldalt",
-      "subtext": "404-es hiba történt."
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "A termék mennyisége csak {{ step }} darabos lépésekben növelhető"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Ország/régió",
     "language_label": "Nyelv",

--- a/locales/id.json
+++ b/locales/id.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "Termasuk pajak.",
       "duties_included": "Termasuk bea cukai.",
-      "duties_and_taxes_included": "Termasuk bea cukai dan pajak."
+      "duties_and_taxes_included": "Termasuk bea cukai dan pajak.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galeri media"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Halaman tidak ditemukan",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Tidak ada hasil ditemukan untuk “{{ terms }}”. Periksa ejaan atau gunakan kata atau frasa yang berbeda.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Mohon sesuaikan:",
         "title": "Formulir kontak"
       }
-    },
-    "404": {
-      "title": "Halaman tidak ditemukan",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Anda hanya dapat menambahkan item ini secara inkremental sebesar {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Negara/Wilayah",
     "language_label": "Bahasa",

--- a/locales/it.json
+++ b/locales/it.json
@@ -178,7 +178,8 @@
       "product_variants": "Varianti di prodotto",
       "taxes_included": "Imposte incluse.",
       "duties_included": "Dazi inclusi.",
-      "duties_and_taxes_included": "Dazi e imposte inclusi."
+      "duties_and_taxes_included": "Dazi e imposte inclusi.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galleria contenuti multimediali"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Pagina non trovata",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Nessun risultato per \"{{ terms }}\". Controlla l'ortografia o usa una parola o una frase diversa.",
       "page": "Pagina",
@@ -267,10 +272,6 @@
         "error_heading": "Correggi gli errori seguenti:",
         "title": "Modulo di contatto"
       }
-    },
-    "404": {
-      "title": "Pagina non trovata",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Puoi aggiungere questo articolo solo in incrementi di {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Paese/Area geografica",
     "language_label": "Lingua",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "税込。",
       "duties_included": "関税込。",
-      "duties_and_taxes_included": "関税と税金が含まれます。"
+      "duties_and_taxes_included": "関税と税金が含まれます。",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "メディアギャラリー"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "ページが見つかりません",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "「{{ terms }}」に一致する結果は見つかりませんでした。スペルを確認するか、別の単語やフレーズを使用してください。",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "以下を確認してください。",
         "title": "お問い合わせフォーム"
       }
-    },
-    "404": {
-      "title": "ページが見つかりません",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "このアイテムは、{{ step }}の増分でのみ追加できます"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "国/地域",
     "language_label": "言語",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "세금이 포함된 가격입니다.",
       "duties_included": "관세가 포함된 가격입니다.",
-      "duties_and_taxes_included": "관세 및 세금이 포함된 가격입니다."
+      "duties_and_taxes_included": "관세 및 세금이 포함된 가격입니다.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "미디어 갤러리"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "페이지를 찾을 수 없음",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "\"{{ terms }}\"에 대한 검색 결과가 없습니다. 철자를 확인하거나 다른 단어/문구를 사용해 보십시오.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "다음을 조정하십시오.",
         "title": "연락처 양식"
       }
-    },
-    "404": {
-      "title": "페이지를 찾을 수 없음",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "이 품목은 {{ step }}개 단위로만 추가할 수 있습니다."
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "국가/지역",
     "language_label": "언어",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -179,7 +179,8 @@
       },
       "taxes_included": "Mokesčiai įtraukti.",
       "duties_included": "Muito mokesčiai įtraukti.",
-      "duties_and_taxes_included": "Muito ir kiti mokesčiai įtraukti."
+      "duties_and_taxes_included": "Muito ir kiti mokesčiai įtraukti.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Medijų galerija"
@@ -223,6 +224,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Puslapis nerastas",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Nerasta jokių rezultatų pagal užklausą „{{ terms }}“. Patikrinkite rašybą arba vartokite kitą žodį ar frazę.",
       "page": "Puslapis",
@@ -276,10 +281,6 @@
         "error_heading": "Pakoreguokite toliau pateiktą informaciją.",
         "title": "Kontaktinė forma"
       }
-    },
-    "404": {
-      "title": "Puslapis nerastas",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -397,16 +398,16 @@
       "step_error": "Galima pridėti tik po {{ step }} vnt. šios prekės"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Šalis / regionas",
     "language_label": "Kalba",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -177,7 +177,8 @@
       "product_variants": "Produktvarianter",
       "taxes_included": "Inkludert avgifter.",
       "duties_included": "Inkluder tollplikter.",
-      "duties_and_taxes_included": "Inkludert tollplikter og avgifter."
+      "duties_and_taxes_included": "Inkludert tollplikter og avgifter.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Mediegalleri"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Siden finnes ikke",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Fant ingen resultater for «{{ terms }}». Kontroller stavemåten, eller bruk et annet ord.",
       "page": "Side",
@@ -258,10 +263,6 @@
         "error_heading": "Juster følgende:",
         "title": "Kontaktskjema"
       }
-    },
-    "404": {
-      "title": "Siden finnes ikke",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Du kan bare legge til denne varen i multipler av {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Land/region",
     "language_label": "Språk",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -177,7 +177,8 @@
       "product_variants": "Productvarianten",
       "taxes_included": "Belastingen inbegrepen.",
       "duties_included": "Douanerechten inbegrepen.",
-      "duties_and_taxes_included": "Douanerechten en belastingen inbegrepen."
+      "duties_and_taxes_included": "Douanerechten en belastingen inbegrepen.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Mediagalerij"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Pagina niet gevonden",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Geen resultaten gevonden voor “{{ terms }}”. Controleer de spelling of gebruik een ander woord of een andere zin.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Pas het volgende aan:",
         "title": "Contactformulier"
       }
-    },
-    "404": {
-      "title": "Pagina niet gevonden",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Je kunt dit artikel alleen toevoegen in stappen van {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Land/regio",
     "language_label": "Taal",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -179,7 +179,8 @@
       "product_variants": "Warianty produktów",
       "taxes_included": "Z wliczonymi podatkami.",
       "duties_included": "Z wliczonymi cłami.",
-      "duties_and_taxes_included": "Z wliczonymi cłami i podatkami."
+      "duties_and_taxes_included": "Z wliczonymi cłami i podatkami.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galeria multimediów"
@@ -223,6 +224,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Nie znaleziono strony",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Nie znaleziono wyników dla “{{ terms }}”. Sprawdź pisownię lub użyj innego słowa lub zwrotu.",
       "page": "Strona",
@@ -276,10 +281,6 @@
         "error_heading": "Dostosuj następujące dane:",
         "title": "Formularz kontaktowy"
       }
-    },
-    "404": {
-      "title": "Nie znaleziono strony",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -397,16 +398,16 @@
       "step_error": "Możesz dodać tę pozycję tylko z przyrostem o {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Kraj/region",
     "language_label": "Język",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -178,7 +178,8 @@
       "product_variants": "Variantes do produto",
       "taxes_included": "Tributos incluídos.",
       "duties_included": "Tributos de importação incluídos.",
-      "duties_and_taxes_included": "Tributos de importação e outros tributos incluídos."
+      "duties_and_taxes_included": "Tributos de importação e outros tributos incluídos.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galeria de mídia"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Página não encontrada",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Não foram encontrados resultados para “{{ terms }}”. Verifique a ortografia ou use uma palavra ou frase diferente.",
       "results_with_count": {
@@ -267,10 +272,6 @@
         "error_heading": "Ajuste o seguinte:",
         "title": "Formulário de contato"
       }
-    },
-    "404": {
-      "title": "Página não encontrada",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Só é possível adicionar este item em incrementos de {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "País/Região",
     "language_label": "Idioma",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -178,7 +178,8 @@
       },
       "taxes_included": "Impostos incluídos.",
       "duties_included": "Encargos incluídos.",
-      "duties_and_taxes_included": "Encargos e impostos incluídos."
+      "duties_and_taxes_included": "Encargos e impostos incluídos.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galeria de conteúdo multimédia"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Página não encontrada",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Não foram encontrados resultados para \"{{ terms }}\". Verifique a ortografia ou utilize uma palavra ou frase diferente.",
       "page": "Página",
@@ -267,10 +272,6 @@
         "error_heading": "Ajuste o seguinte:",
         "title": "Formulário de contacto"
       }
-    },
-    "404": {
-      "title": "Página não encontrada",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Só pode adicionar este item em incrementos de {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "País/região",
     "language_label": "Idioma",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -178,7 +178,8 @@
       },
       "taxes_included": "Taxe incluse.",
       "duties_included": "Taxe vamale incluse.",
-      "duties_and_taxes_included": "Taxe și taxe vamale incluse."
+      "duties_and_taxes_included": "Taxe și taxe vamale incluse.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galerie media"
@@ -219,6 +220,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Pagina nu a fost găsită",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Nu s-au găsit rezultate pentru „{{ terms }}”. Verificați ortografia sau utilizați alt cuvânt sau altă expresie.",
       "title": "Rezultatele căutării",
@@ -267,10 +272,6 @@
         "error_heading": "Vă rugăm să ajustați următoarele:",
         "title": "Formular de contact"
       }
-    },
-    "404": {
-      "title": "Pagina nu a fost găsită",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -385,16 +386,16 @@
       "step_error": "Poți introduce acest articol numai în incrementuri de {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Țară/Regiune",
     "language_label": "Limbă",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -179,7 +179,8 @@
       "product_variants": "Варианты товара",
       "taxes_included": "Налоги включены.",
       "duties_included": "Пошлины включены.",
-      "duties_and_taxes_included": "Пошлины и налоги включены."
+      "duties_and_taxes_included": "Пошлины и налоги включены.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Галерея мультимедиа"
@@ -223,6 +224,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Страница не найдена",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "По запросу «{{ terms }}» ничего не найдено. Проверьте правописание или выберите другие слова либо фразу.",
       "title": "Результаты поиска",
@@ -276,10 +281,6 @@
         "error_heading": "Измените следующие элементы:",
         "title": "Форма для связи"
       }
-    },
-    "404": {
-      "title": "Страница не найдена",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -397,16 +398,16 @@
       "step_error": "Вы можете добавить этот товар только в количестве, кратном {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Страна/регион",
     "language_label": "Язык",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -179,7 +179,8 @@
       },
       "taxes_included": "Vrátane daní.",
       "duties_included": "Vrátane ciel.",
-      "duties_and_taxes_included": "Vrátane ciel a daní."
+      "duties_and_taxes_included": "Vrátane ciel a daní.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galéria médií"
@@ -223,6 +224,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Stránka sa nenašla",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Pre výraz „{{ terms }}“ sa nenašli žiadne výsledky. Skontrolujte pravopis alebo použite iné slovo či slovné spojenie.",
       "title": "Výsledky vyhľadávania",
@@ -276,10 +281,6 @@
         "error_heading": "Upravte tieto údaje:",
         "title": "Kontaktný formulár"
       }
-    },
-    "404": {
-      "title": "Stránka sa nenašla",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -397,16 +398,16 @@
       "step_error": "Túto položku môžete pridať iba v prírastkoch po {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Krajina/oblasť",
     "language_label": "Jazyk",

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -179,7 +179,8 @@
       },
       "taxes_included": "Davki vključeni.",
       "duties_included": "Dajatve vključene.",
-      "duties_and_taxes_included": "Dajatve in davki vključeni."
+      "duties_and_taxes_included": "Dajatve in davki vključeni.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Galerija predstavnostnih vsebin"
@@ -223,6 +224,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Strani ni mogoče najti",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Za »{{ terms }}« ni bil najden noben rezultat. Preverite črkovanje ali uporabite drugo besedo ali frazo.",
       "page": "Stran",
@@ -276,10 +281,6 @@
         "error_heading": "Prilagodite naslednje:",
         "title": "Obrazec za stik"
       }
-    },
-    "404": {
-      "title": "Strani ni mogoče najti",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -397,16 +398,16 @@
       "step_error": "Ta artikel lahko dodate samo v korakih po {{ step }}."
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Država/regija",
     "language_label": "Jezik",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -177,7 +177,8 @@
       "product_variants": "Produktvarianter",
       "taxes_included": "Skatter ingår.",
       "duties_included": "Tullavgifter ingår.",
-      "duties_and_taxes_included": "Tullavgifter och skatter ingår."
+      "duties_and_taxes_included": "Tullavgifter och skatter ingår.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Mediagalleri"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Sidan hittades inte",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Inga resultat hittades för \"{{ terms }}\". Kontrollera stavningen eller använd ett annat ord eller fras.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Justera följande:",
         "title": "Kontaktformulär"
       }
-    },
-    "404": {
-      "title": "Sidan hittades inte",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Du kan endast lägga till den här artikeln med ökningar om {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Land/Region",
     "language_label": "Språk",

--- a/locales/th.json
+++ b/locales/th.json
@@ -177,7 +177,8 @@
       "product_variants": "ตัวเลือกสินค้า",
       "taxes_included": "รวมภาษีแล้ว",
       "duties_included": "รวมอากรแล้ว",
-      "duties_and_taxes_included": "รวมภาษีและอากรแล้ว"
+      "duties_and_taxes_included": "รวมภาษีและอากรแล้ว",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "แกลเลอรีสื่อ"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "ไม่พบหน้า",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "ไม่พบผลลัพธ์สำหรับ “{{ terms }}” ตรวจสอบการสะกดคำหรือลองค้นหาคำอื่น",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "โปรดแก้ไขข้อมูลดังต่อไปนี้:",
         "title": "แบบฟอร์มการติดต่อ"
       }
-    },
-    "404": {
-      "title": "ไม่พบหน้า",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "คุณสามารถเพิ่มสินค้านี้ได้ทีละ {{ step }} รายการในแต่ละครั้งเท่านั้น"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "ประเทศ/ภูมิภาค",
     "language_label": "ภาษา",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -177,7 +177,8 @@
       "product_variants": "Ürün varyasyonları",
       "taxes_included": "Vergiler dahil.",
       "duties_included": "Gümrük vergileri dahil.",
-      "duties_and_taxes_included": "Vergiler ve gümrük vergileri dahil."
+      "duties_and_taxes_included": "Vergiler ve gümrük vergileri dahil.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Medya galerisi"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Sayfa bulunamadı",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "\"{{ terms }}\" için sonuç bulunamadı. Yazım hatası olmadığını doğrulayın veya farklı bir kelime ya da ifade kullanın.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Lütfen aşağıdakileri düzenleyin:",
         "title": "İletişim formu"
       }
-    },
-    "404": {
-      "title": "Sayfa bulunamadı",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Bu öğeyi yalnızca {{ step }} değerinde artışlarla ekleyebilirsiniz"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Ülke/bölge",
     "language_label": "Dil",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "Đã bao gồm thuế.",
       "duties_included": "Đã bao gồm thuế nhập khẩu.",
-      "duties_and_taxes_included": "Đã bao gồm thuế và thuế nhập khẩu."
+      "duties_and_taxes_included": "Đã bao gồm thuế và thuế nhập khẩu.",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "Thư viện phương tiện"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "Không tìm thấy trang",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "Không tìm thấy kết quả cho \"{{ terms }}\". Kiểm tra chính tả hoặc sử dụng một từ hoặc cụm từ khác.",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "Vui lòng điều chỉnh các mục sau:",
         "title": "Biểu mẫu liên hệ"
       }
-    },
-    "404": {
-      "title": "Không tìm thấy trang",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "Bạn chỉ có thể thêm mặt hàng này theo đơn vị giao dịch {{ step }}"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "Quốc gia/khu vực",
     "language_label": "Ngôn ngữ",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "已含税费。",
       "duties_included": "已含关税。",
-      "duties_and_taxes_included": "已含关税和税费。"
+      "duties_and_taxes_included": "已含关税和税费。",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "媒体图库"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "找不到页面",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "未找到“{{ terms }}”的结果。请检查拼写或使用其他词或短语。",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "请调整以下内容：",
         "title": "联系表"
       }
-    },
-    "404": {
-      "title": "找不到页面",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "您只能以 {{ step }} 为增量来添加此商品"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "国家/地区",
     "language_label": "语言",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -177,7 +177,8 @@
       },
       "taxes_included": "已包含稅額。",
       "duties_included": "已包含關稅。",
-      "duties_and_taxes_included": "已包含關稅和稅額。"
+      "duties_and_taxes_included": "已包含關稅和稅額。",
+      "size_guide": "Size guide"
     },
     "modal": {
       "label": "媒體庫"
@@ -215,6 +216,10 @@
     }
   },
   "templates": {
+    "404": {
+      "title": "找不到頁面",
+      "subtext": "404"
+    },
     "search": {
       "no_results": "找不到與「{{ terms }}」相符的結果。請檢查拼字或使用其他字詞。",
       "results_with_count": {
@@ -258,10 +263,6 @@
         "error_heading": "請調整以下內容：",
         "title": "聯絡表單"
       }
-    },
-    "404": {
-      "title": "找不到頁面",
-      "subtext": "404"
     }
   },
   "sections": {
@@ -373,16 +374,16 @@
       "step_error": "只能以 {{ step }} 為增量新增此品項"
     }
   },
-    "faq": {
-      "title": "FAQ",
-      "question": "Question",
-      "answer": "Answer"
-    },
-    "lookbook": {
-      "title": "Lookbook",
-      "image": "Image",
-      "link": "Link"
-    },
+  "faq": {
+    "title": "FAQ",
+    "question": "Question",
+    "answer": "Answer"
+  },
+  "lookbook": {
+    "title": "Lookbook",
+    "image": "Image",
+    "link": "Link"
+  },
   "localization": {
     "country_label": "國家/地區",
     "language_label": "語言",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vic-dawn-theme",
+  "version": "1.0.0",
+  "description": "**Note**: This repository contains the *LiveSlowDieOld* theme built on top of Dawn. It adds a Lookbook page, FAQ section, and a size guide modal.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/logger.test.js && node tests/cart.test.js"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "./pre-commit"
+    }
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx prettier -c . && bin/theme-check

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -166,12 +166,7 @@
                     class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}"
                     {{ block.shopify_attributes }}
                   >
-                    {% comment %} TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter {% endcomment %}
-                    {% # theme-check-disable %}
-                    {%- assign cart_qty = cart
-                      | item_count_for_variant: product.selected_or_first_available_variant.id
-                    -%}
-                    {% # theme-check-enable %}
+                    {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
                     <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                       {{ 'products.product.quantity.label' | t }}
                       <span class="quantity__rules-cart{% if cart_qty == 0 %} hidden{% endif %}">

--- a/sections/lookbook.liquid
+++ b/sections/lookbook.liquid
@@ -51,7 +51,7 @@
                 height="{{ block.settings.image.height }}"
               >
             {%- else -%}
-              {{ 'image' | placeholder_svg_tag }}
+              {{ 'image' | placeholder_svg_tag: 'placeholder-svg', 'Placeholder image' }}
             {%- endif -%}
           {%- if block.settings.link != blank -%}
             </a>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -233,12 +233,7 @@
                   class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}"
                   {{ block.shopify_attributes }}
                 >
-                  {% comment %} TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter {% endcomment %}
-                  {% # theme-check-disable %}
-                  {%- assign cart_qty = cart
-                    | item_count_for_variant: product.selected_or_first_available_variant.id
-                  -%}
-                  {% # theme-check-enable %}
+                  {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
                   <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                     {{ 'products.product.quantity.label' | t }}
                     <span class="quantity__rules-cart{% if cart_qty == 0 %} hidden{% endif %}">

--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -9,9 +9,7 @@
   {% render 'quick-order-list-row' variant: variant %}
 {% endcomment %}
 
-{% # theme-check-disable %}
 {% assign cart_qty = cart | item_count_for_variant: variant.id %}
-{% # theme-check-enable %}
 
 <tr
   class="variant-item{% unless show_image %} variant-item--no-media{% endunless %}{% if item.available and item.unit_price_measurement %} variant-item--unit-price{% endif %}"
@@ -160,10 +158,7 @@
 
   <td class="variant-item__totals right large-up-hide">
     {%- render 'loading-spinner' -%}
-    {% comment %} TODO: enable theme-check once `line_items_for` is accepted as valid filter {% endcomment %}
-    {% # theme-check-disable %}
     <span class="price">{{ cart | line_items_for: item | sum: 'original_line_price' | money }}</span>
-    {% # theme-check-enable %}
   </td>
 
   <td class="variant-item__quantity">
@@ -276,10 +271,7 @@
           {%- if variant.available == false or quantity_rule_soldout -%}
             <span class="variant-item__sold-out"> {{ 'products.product.sold_out' | t }} </span>
           {%- else -%}
-            {% comment %} TODO: Remove theme check {% endcomment %}
-            {% # theme-check-disable %}
             {% assign cart_qty = cart | item_count_for_variant: variant.id %}
-            {% # theme-check-enable %}
             {% render 'quantity-input', variant: variant, min: 0 %}
           {%- endif -%}
         </div>
@@ -431,10 +423,7 @@
   </td>
   <td class="variant-item__totals right small-hide medium-hide">
     {%- render 'loading-spinner' -%}
-    {% comment %} TODO: enable theme-check once `line_items_for` is accepted as valid filter {% endcomment %}
-    {% # theme-check-disable %}
     <span class="price">{{ cart | line_items_for: item | sum: 'original_line_price' | money }}</span>
-    {% # theme-check-enable %}
   </td>
 </tr>
 <tr class="small-hide medium-hide hidden desktop-row-error">

--- a/snippets/quick-order-list.liquid
+++ b/snippets/quick-order-list.liquid
@@ -10,10 +10,7 @@
   {% render 'quick-order-list', product: product %}
 {% endcomment %}
 
-{% comment %} TODO: enable theme-check once `line_items_for` is accepted as valid filter {% endcomment %}
-{% # theme-check-disable %}
 {%- assign items_in_cart = cart | line_items_for: product | sum: 'quantity' -%}
-{% # theme-check-enable %}
 <div class="quick-order-list-container color-{{ section.settings.color_scheme }}{% unless is_modal %} gradient{% endunless %}">
   <quick-order-list
     class="page-width section-{{ section.id }}-padding"
@@ -175,10 +172,7 @@
           <div class="quick-order-list-total__price">
             <div class="totals__product-total">
               <span class="totals__subtotal-value">
-                {% comment %} TODO: enable theme-check once `line_items_for` is accepted as valid filter {% endcomment %}
-                {% # theme-check-disable %}
                 {{ cart | line_items_for: product | sum: 'original_line_price' | money }}
-                {% # theme-check-enable %}
               </span>
               <p class="totals__subtotal h5">{{ 'sections.quick_order_list.product_total' | t }}</p>
             </div>

--- a/tests/cart.test.js
+++ b/tests/cart.test.js
@@ -1,0 +1,8 @@
+const { strictEqual } = require('assert');
+require('../assets/logger.js');
+let err;
+console.error = (e) => {
+  err = e;
+};
+Logger.error('boom');
+strictEqual(err, 'boom');

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,8 @@
+const { strictEqual } = require('assert');
+require('../assets/logger.js');
+let message;
+console.info = (msg) => {
+  message = msg;
+};
+Logger.info('test');
+strictEqual(message, 'test');


### PR DESCRIPTION
## Summary
- create global Logger for consistent logging
- remove theme-check suppressions for supported filters
- handle logging consistently across JS
- mark theme-check script executable
- add minimal Node tests and GitHub Actions workflow for them
- document extra features with screenshot references
- add placeholder documentation images
- provide missing `size_guide` keys for locales
- add placeholder pre-commit hook for formatting

## Testing
- `npm test`
- `bin/theme-check` *(fails: theme-check is not installed)*
