### PR TITLE
Add fancy hero section with GSAP animation

### DIFF
--- a/assets/fancy-hero.css
+++ b/assets/fancy-hero.css
@@ -1,0 +1,21 @@
+.fancy-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80vh;
+  overflow: hidden;
+}
+
+.fancy-hero model-viewer {
+  width: 100%;
+  height: 60vh;
+}
+
+.fancy-hero__content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+}

--- a/assets/fancy-hero.js
+++ b/assets/fancy-hero.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const hero = document.querySelector('.fancy-hero');
+  if (!hero || typeof gsap === 'undefined') return;
+
+  const heading = hero.querySelector('.fancy-hero__heading');
+  const subtext = hero.querySelector('.fancy-hero__subtext');
+  const model = hero.querySelector('model-viewer');
+
+  gsap.from(heading, { y: -40, opacity: 0, duration: 1 });
+  gsap.from(subtext, { y: 40, opacity: 0, duration: 1, delay: 0.2 });
+  gsap.from(model, { opacity: 0, duration: 1, delay: 0.4 });
+});

--- a/sections/fancy-hero.liquid
+++ b/sections/fancy-hero.liquid
@@ -1,0 +1,58 @@
+{{ 'fancy-hero.css' | asset_url | stylesheet_tag }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer="defer"></script>
+<script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+
+<div class="fancy-hero">
+  <model-viewer src="{{ section.settings.model_src }}" auto-rotate camera-controls></model-viewer>
+  <div class="fancy-hero__content">
+    <h1 class="fancy-hero__heading">{{ section.settings.heading }}</h1>
+    <p class="fancy-hero__subtext">{{ section.settings.subtext }}</p>
+    {% if section.settings.button_label != blank %}
+      <a href="{{ section.settings.button_link }}" class="button">{{ section.settings.button_label }}</a>
+    {% endif %}
+  </div>
+</div>
+
+<script src="{{ 'fancy-hero.js' | asset_url }}" defer="defer"></script>
+
+{% schema %}
+{
+  "name": "Fancy hero",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Welcome"
+    },
+    {
+      "type": "textarea",
+      "id": "subtext",
+      "label": "Subtext",
+      "default": "A stylish hero section with a 3D model."
+    },
+    {
+      "type": "url",
+      "id": "model_src",
+      "label": "3D model URL",
+      "default": "https://modelviewer.dev/shared-assets/models/Astronaut.glb"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Button label",
+      "default": "Shop now"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Button link"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Fancy hero"
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,5 +1,15 @@
 {
   "sections": {
+    "fancy_hero": {
+      "type": "fancy-hero",
+      "settings": {
+        "heading": "Fancy hero",
+        "subtext": "Experience 3D interactions",
+        "model_src": "https://modelviewer.dev/shared-assets/models/Astronaut.glb",
+        "button_label": "Shop now",
+        "button_link": "/collections/all"
+      }
+    },
     "image_banner": {
       "type": "image-banner",
       "blocks": {
@@ -29,11 +39,7 @@
           }
         }
       },
-      "block_order": [
-        "heading",
-        "text",
-        "button"
-      ],
+      "block_order": ["heading", "text", "button"],
       "settings": {
         "image_overlay_opacity": 40,
         "image_height": "large",
@@ -63,10 +69,7 @@
           }
         }
       },
-      "block_order": [
-        "heading",
-        "text"
-      ],
+      "block_order": ["heading", "text"],
       "settings": {
         "color_scheme": "scheme-1",
         "full_width": true,
@@ -117,11 +120,7 @@
           }
         }
       },
-      "block_order": [
-        "collection-0",
-        "product",
-        "collection-1"
-      ],
+      "block_order": ["collection-0", "product", "collection-1"],
       "settings": {
         "heading": "Multimedia collage",
         "heading_size": "h2",
@@ -176,11 +175,7 @@
           }
         }
       },
-      "block_order": [
-        "column1",
-        "column2",
-        "column3"
-      ],
+      "block_order": ["column1", "column2", "column3"],
       "settings": {
         "title": "",
         "heading_size": "h1",
@@ -199,12 +194,5 @@
       }
     }
   },
-  "order": [
-    "image_banner",
-    "rich_text",
-    "featured_collection",
-    "collage",
-    "video",
-    "multicolumn"
-  ]
+  "order": ["fancy_hero", "image_banner", "rich_text", "featured_collection", "collage", "video", "multicolumn"]
 }


### PR DESCRIPTION
## Summary
- create fancy hero section using `<model-viewer>` for 3D models
- animate hero content with GSAP
- expose hero settings in schema
- include new section on the home template

## Testing
- `npx prettier -c assets/fancy-hero.css assets/fancy-hero.js sections/fancy-hero.liquid templates/index.json`
- `bash bin/theme-check` *(fails: theme-check not installed)*
- `npm test`